### PR TITLE
Correct handling of DATETIME and TIME columns

### DIFF
--- a/src/MariaRow.cpp
+++ b/src/MariaRow.cpp
@@ -46,11 +46,11 @@ void MariaRow::setUp(MYSQL_STMT* pStatement, const std::vector<MariaFieldType>& 
       buffers_[i].resize(sizeof(MYSQL_TIME));
       break;
     case MY_DATE_TIME:
-      bindings_[i].buffer_type = MYSQL_TYPE_TIME;
+      bindings_[i].buffer_type = MYSQL_TYPE_DATETIME;
       buffers_[i].resize(sizeof(MYSQL_TIME));
       break;
     case MY_TIME:
-      bindings_[i].buffer_type = MYSQL_TYPE_DATETIME;
+      bindings_[i].buffer_type = MYSQL_TYPE_TIME;
       buffers_[i].resize(sizeof(MYSQL_TIME));
       break;
     case MY_STR:


### PR DESCRIPTION
After switching from RMySQL to RMariaDB we got garbled data back from `DATETIME` columns.  Instead of a proper datetime like `2017-08-16 12:00:00` we would instead see something like `-12-07 ...` (I don't remember the exact details but it looked truncated).

If this was caused by accidently swapping the data type for DATETIME and TIME, this PR might fix it.  At least it seems to work for us.

Could you please test the below script with this patch and/or check the comments and see if it looks sane to you?

```
library(RMariaDB)

db = dbConnect(MariaDB(), user='debug', password='debug', dbname='debug', host='127.0.0.1', port=4001)

dbGetQuery(db, 'CREATE TABLE IF NOT EXISTS issue52 (d DATE, t TIME, dt DATETIME, ts TIMESTAMP)')
dbGetQuery(db, 'INSERT INTO issue52 SET d=UTC_DATE(), t=UTC_TIME(), dt=UTC_TIMESTAMP(), ts=UTC_TIMESTAMP()')
res = dbGetQuery(db, 'SELECT d, t, dt, ts FROM issue52')
# The MySQL command line client would return something similar to:
# 2017-08-16 | 14:00:00 | 2017-08-16 14:00:00 | 2017-08-16 14:00:00
#
# With this PR, RMariaDB returns something similar to:
# 1 | 2017-08-16 | 50406 | 2017-08-16 | 14:00:06 | 2017-08-16 14:00:06
print(res)
dbDisconnect(db)
```

Thanks.