### PR TITLE
Get result metadata for queries that bypass PS framework

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -53,8 +53,8 @@ init_logging <- function(log_level) {
     invisible(.Call(`_RMariaDB_init_logging`, log_level))
 }
 
-result_create <- function(con, sql, is_stmnt = FALSE) {
-    .Call(`_RMariaDB_result_create`, con, sql, is_stmnt)
+result_create <- function(con, sql, is_statement = FALSE) {
+    .Call(`_RMariaDB_result_create`, con, sql, is_statement)
 }
 
 result_column_info <- function(rs) {

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -53,8 +53,8 @@ init_logging <- function(log_level) {
     invisible(.Call(`_RMariaDB_init_logging`, log_level))
 }
 
-result_create <- function(con, sql) {
-    .Call(`_RMariaDB_result_create`, con, sql)
+result_create <- function(con, sql, is_stmnt = FALSE) {
+    .Call(`_RMariaDB_result_create`, con, sql, is_stmnt)
 }
 
 result_column_info <- function(rs) {

--- a/R/query.R
+++ b/R/query.R
@@ -56,7 +56,7 @@ setMethod("dbFetch", "MariaDBResult",
 #' @export
 setMethod("dbSendQuery", c("MariaDBConnection", "character"),
   function(conn, statement, params = NULL, ...) {
-    dbSend(conn, statement, params, FALSE)
+    dbSend(conn, statement, params, is_statement = FALSE)
   }
 )
 
@@ -64,16 +64,16 @@ setMethod("dbSendQuery", c("MariaDBConnection", "character"),
 #' @export
 setMethod("dbSendStatement", signature("MariaDBConnection", "character"),
   function(conn, statement, params = NULL, ...) {
-    dbSend(conn, statement, params, TRUE)
+    dbSend(conn, statement, params, is_statement = TRUE)
   }
 )
 
-dbSend <- function(conn, statement, params = NULL, is.stmnt = FALSE) {
+dbSend <- function(conn, statement, params = NULL, is_statement) {
   statement <- enc2utf8(statement)
 
   rs <- new("MariaDBResult",
     sql = statement,
-    ptr = result_create(conn@ptr, statement, is.stmnt)
+    ptr = result_create(conn@ptr, statement, is_statement)
   )
 
   if (!is.null(params)) {

--- a/R/query.R
+++ b/R/query.R
@@ -7,7 +7,10 @@ NULL
 #' To retrieve results a chunk at a time, use [dbSendQuery()],
 #' [dbFetch()], then [dbClearResult()]. Alternatively, if you want all the
 #' results (and they'll fit in memory) use [dbGetQuery()] which sends,
-#' fetches and clears for you.
+#' fetches and clears for you. For data manipulation queries (i.e. queries
+#' that do not return data, such as \code{UPDATE}, \code{DELETE}, etc.),
+#' [dbSendStatement()] serves as a counterpart to [dbSendQuery()], while
+#' [dbExecute()] corresponds to [dbGetQuery()].
 #'
 #' @param conn an [MariaDBConnection-class] object.
 #' @param res A  [MariaDBResult-class] object.
@@ -53,22 +56,33 @@ setMethod("dbFetch", "MariaDBResult",
 #' @export
 setMethod("dbSendQuery", c("MariaDBConnection", "character"),
   function(conn, statement, params = NULL, ...) {
-    statement <- enc2utf8(statement)
-
-    is_stmnt <- any(grepl("dbSendStatement", sys.calls()))
-
-    rs <- new("MariaDBResult",
-      sql = statement,
-      ptr = result_create(conn@ptr, statement, is_stmnt)
-    )
-
-    if (!is.null(params)) {
-      dbBind(rs, params)
-    }
-
-    rs
+    dbSend(conn, statement, params, FALSE)
   }
 )
+
+#' @rdname query
+#' @export
+setMethod("dbSendStatement", signature("MariaDBConnection", "character"),
+  function(conn, statement, ...) {
+    dbSend(conn, statement, NULL, TRUE)
+  }
+)
+
+dbSend <- function(conn, statement, params = NULL, is.stmnt = FALSE) {
+  statement <- enc2utf8(statement)
+
+  rs <- new("MariaDBResult",
+    sql = statement,
+    ptr = result_create(conn@ptr, statement, is.stmnt)
+  )
+
+  if (!is.null(params)) {
+    dbBind(rs, params)
+  }
+
+  rs
+}
+
 
 #' @rdname query
 #' @export

--- a/R/query.R
+++ b/R/query.R
@@ -55,9 +55,11 @@ setMethod("dbSendQuery", c("MariaDBConnection", "character"),
   function(conn, statement, params = NULL, ...) {
     statement <- enc2utf8(statement)
 
+    is_stmnt <- any(grepl("dbSendStatement", sys.calls()))
+
     rs <- new("MariaDBResult",
       sql = statement,
-      ptr = result_create(conn@ptr, statement)
+      ptr = result_create(conn@ptr, statement, is_stmnt)
     )
 
     if (!is.null(params)) {

--- a/R/query.R
+++ b/R/query.R
@@ -63,8 +63,8 @@ setMethod("dbSendQuery", c("MariaDBConnection", "character"),
 #' @rdname query
 #' @export
 setMethod("dbSendStatement", signature("MariaDBConnection", "character"),
-  function(conn, statement, ...) {
-    dbSend(conn, statement, NULL, TRUE)
+  function(conn, statement, params = NULL, ...) {
+    dbSend(conn, statement, params, TRUE)
   }
 )
 

--- a/man/RMariaDB-package.Rd
+++ b/man/RMariaDB-package.Rd
@@ -4,9 +4,9 @@
 \name{RMariaDB-package}
 \alias{RMariaDB}
 \alias{RMariaDB-package}
-\title{RMariaDB: Database Interface and 'MariaDB' Driver for R}
+\title{RMariaDB: Database Interface and 'MariaDB' Driver}
 \description{
-Implements a 'DBI'-compliant interface to 'MariaDB' and 'MySQL' databases.
+Implements a 'DBI'-compliant interface to 'MariaDB' (<https://mariadb.org/>) and 'MySQL' (<https://www.mysql.com/>) databases.
 }
 \seealso{
 Useful links:

--- a/man/query.Rd
+++ b/man/query.Rd
@@ -15,7 +15,8 @@
 \S4method{dbSendQuery}{MariaDBConnection,character}(conn, statement,
   params = NULL, ...)
 
-\S4method{dbSendStatement}{MariaDBConnection,character}(conn, statement, ...)
+\S4method{dbSendStatement}{MariaDBConnection,character}(conn, statement,
+  params = NULL, ...)
 
 \S4method{dbBind}{MariaDBResult}(res, params, ...)
 
@@ -54,7 +55,10 @@ a parameterised query.}
 To retrieve results a chunk at a time, use \code{\link[=dbSendQuery]{dbSendQuery()}},
 \code{\link[=dbFetch]{dbFetch()}}, then \code{\link[=dbClearResult]{dbClearResult()}}. Alternatively, if you want all the
 results (and they'll fit in memory) use \code{\link[=dbGetQuery]{dbGetQuery()}} which sends,
-fetches and clears for you.
+fetches and clears for you. For data manipulation queries (i.e. queries
+that do not return data, such as \code{UPDATE}, \code{DELETE}, etc.),
+\code{\link[=dbSendStatement]{dbSendStatement()}} serves as a counterpart to \code{\link[=dbSendQuery]{dbSendQuery()}}, while
+\code{\link[=dbExecute]{dbExecute()}} corresponds to \code{\link[=dbGetQuery]{dbGetQuery()}}.
 }
 \examples{
 if (mariadbHasDefault()) {

--- a/man/query.Rd
+++ b/man/query.Rd
@@ -4,6 +4,7 @@
 \name{dbFetch,MariaDBResult-method}
 \alias{dbFetch,MariaDBResult-method}
 \alias{dbSendQuery,MariaDBConnection,character-method}
+\alias{dbSendStatement,MariaDBConnection,character-method}
 \alias{dbBind,MariaDBResult-method}
 \alias{dbClearResult,MariaDBResult-method}
 \alias{dbGetStatement,MariaDBResult-method}
@@ -13,6 +14,8 @@
 
 \S4method{dbSendQuery}{MariaDBConnection,character}(conn, statement,
   params = NULL, ...)
+
+\S4method{dbSendStatement}{MariaDBConnection,character}(conn, statement, ...)
 
 \S4method{dbBind}{MariaDBResult}(res, params, ...)
 

--- a/src/MariaResult.cpp
+++ b/src/MariaResult.cpp
@@ -34,13 +34,14 @@ void MariaResult::autocommit() {
   maria_conn->autocommit();
 }
 
-MariaResult* MariaResult::create_and_send_query(MariaConnectionPtr con, const std::string& sql, bool is_stmnt) {
-  std::auto_ptr<MariaResult> res(new MariaResultPrep(con, is_stmnt));
+MariaResult* MariaResult::create_and_send_query(MariaConnectionPtr con, const std::string& sql, bool is_statement) {
+  std::auto_ptr<MariaResult> res(new MariaResultPrep(con, is_statement));
   try {
     res->send_query(sql);
   }
   catch (MariaResultPrep::UnsupportedPS e) {
     res.reset(NULL);
+    // is_statement info might be worthwhile to pass to simple queries as well 
     res.reset(new MariaResultSimple(con));
     res->send_query(sql);
   }

--- a/src/MariaResult.cpp
+++ b/src/MariaResult.cpp
@@ -34,8 +34,8 @@ void MariaResult::autocommit() {
   maria_conn->autocommit();
 }
 
-MariaResult* MariaResult::create_and_send_query(MariaConnectionPtr con, const std::string& sql) {
-  std::auto_ptr<MariaResult> res(new MariaResultPrep(con));
+MariaResult* MariaResult::create_and_send_query(MariaConnectionPtr con, const std::string& sql, bool is_stmnt) {
+  std::auto_ptr<MariaResult> res(new MariaResultPrep(con, is_stmnt));
   try {
     res->send_query(sql);
   }

--- a/src/MariaResult.h
+++ b/src/MariaResult.h
@@ -36,7 +36,7 @@ protected:
   void autocommit();
 
 public:
-  static MariaResult* create_and_send_query(MariaConnectionPtr con, const std::string& sql);
+  static MariaResult* create_and_send_query(MariaConnectionPtr con, const std::string& sql, bool is_stmnt = false);
 
 private:
   MariaConnectionPtr maria_conn;

--- a/src/MariaResult.h
+++ b/src/MariaResult.h
@@ -36,7 +36,7 @@ protected:
   void autocommit();
 
 public:
-  static MariaResult* create_and_send_query(MariaConnectionPtr con, const std::string& sql, bool is_stmnt = false);
+  static MariaResult* create_and_send_query(MariaConnectionPtr con, const std::string& sql, bool is_statement);
 
 private:
   MariaConnectionPtr maria_conn;

--- a/src/MariaResultPrep.cpp
+++ b/src/MariaResultPrep.cpp
@@ -80,6 +80,10 @@ void MariaResultPrep::execute() {
   if (mysql_stmt_execute(pStatement_) != 0)
     throw_error();
   if (!has_result()) {
+    // try again after mysql_stmt_execute, in case pSpec_ == NULL
+    pSpec_ = mysql_stmt_result_metadata(pStatement_);
+  }
+  if (!has_result()) {
     rowsAffected_ += mysql_stmt_affected_rows(pStatement_);
   }
 }

--- a/src/MariaResultPrep.cpp
+++ b/src/MariaResultPrep.cpp
@@ -4,7 +4,7 @@
 #include "MariaConnection.h"
 #include <mysqld_error.h>
 
-MariaResultPrep::MariaResultPrep(MariaConnectionPtr conn) :
+MariaResultPrep::MariaResultPrep(MariaConnectionPtr conn, bool is_stmnt) :
   MariaResult(conn),
   pStatement_(NULL),
   pSpec_(NULL),
@@ -13,7 +13,8 @@ MariaResultPrep::MariaResultPrep(MariaConnectionPtr conn) :
   nCols_(0),
   nParams_(0),
   bound_(false),
-  complete_(false)
+  complete_(false),
+  is_stmnt_(is_stmnt)
 {
   pStatement_ = mysql_stmt_init(get_conn());
   if (pStatement_ == NULL)
@@ -79,7 +80,7 @@ void MariaResultPrep::execute() {
 
   if (mysql_stmt_execute(pStatement_) != 0)
     throw_error();
-  if (!has_result()) {
+  if (!has_result() && !is_stmnt_) {
     // try again after mysql_stmt_execute, in case pSpec_ == NULL
     pSpec_ = mysql_stmt_result_metadata(pStatement_);
   }

--- a/src/MariaResultPrep.cpp
+++ b/src/MariaResultPrep.cpp
@@ -4,7 +4,7 @@
 #include "MariaConnection.h"
 #include <mysqld_error.h>
 
-MariaResultPrep::MariaResultPrep(MariaConnectionPtr conn, bool is_stmnt) :
+MariaResultPrep::MariaResultPrep(MariaConnectionPtr conn, bool is_statement) :
   MariaResult(conn),
   pStatement_(NULL),
   pSpec_(NULL),
@@ -14,7 +14,7 @@ MariaResultPrep::MariaResultPrep(MariaConnectionPtr conn, bool is_stmnt) :
   nParams_(0),
   bound_(false),
   complete_(false),
-  is_stmnt_(is_stmnt)
+  is_statement_(is_statement)
 {
   pStatement_ = mysql_stmt_init(get_conn());
   if (pStatement_ == NULL)
@@ -80,7 +80,7 @@ void MariaResultPrep::execute() {
 
   if (mysql_stmt_execute(pStatement_) != 0)
     throw_error();
-  if (!has_result() && !is_stmnt_) {
+  if (!has_result() && !is_statement_) {
     // try again after mysql_stmt_execute, in case pSpec_ == NULL
     pSpec_ = mysql_stmt_result_metadata(pStatement_);
   }

--- a/src/MariaResultPrep.h
+++ b/src/MariaResultPrep.h
@@ -16,6 +16,7 @@ class MariaResultPrep : boost::noncopyable, public MariaResult {
 
   int nCols_, nParams_;
   bool bound_, complete_;
+  bool is_stmnt_;
 
   std::vector<MariaFieldType> types_;
   std::vector<std::string> names_;
@@ -23,7 +24,7 @@ class MariaResultPrep : boost::noncopyable, public MariaResult {
   MariaRow bindingOutput_;
 
 public:
-  MariaResultPrep(MariaConnectionPtr conn);
+  MariaResultPrep(MariaConnectionPtr conn, bool is_stmnt = false);
   ~MariaResultPrep();
 
 public:

--- a/src/MariaResultPrep.h
+++ b/src/MariaResultPrep.h
@@ -16,7 +16,7 @@ class MariaResultPrep : boost::noncopyable, public MariaResult {
 
   int nCols_, nParams_;
   bool bound_, complete_;
-  bool is_stmnt_;
+  bool is_statement_;
 
   std::vector<MariaFieldType> types_;
   std::vector<std::string> names_;
@@ -24,7 +24,7 @@ class MariaResultPrep : boost::noncopyable, public MariaResult {
   MariaRow bindingOutput_;
 
 public:
-  MariaResultPrep(MariaConnectionPtr conn, bool is_stmnt = false);
+  MariaResultPrep(MariaConnectionPtr conn, bool is_statement = false);
   ~MariaResultPrep();
 
 public:

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -154,14 +154,15 @@ BEGIN_RCPP
 END_RCPP
 }
 // result_create
-XPtr<MariaResult> result_create(XPtr<MariaConnectionPtr> con, std::string sql);
-RcppExport SEXP _RMariaDB_result_create(SEXP conSEXP, SEXP sqlSEXP) {
+XPtr<MariaResult> result_create(XPtr<MariaConnectionPtr> con, std::string sql, bool is_stmnt);
+RcppExport SEXP _RMariaDB_result_create(SEXP conSEXP, SEXP sqlSEXP, SEXP is_stmntSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< XPtr<MariaConnectionPtr> >::type con(conSEXP);
     Rcpp::traits::input_parameter< std::string >::type sql(sqlSEXP);
-    rcpp_result_gen = Rcpp::wrap(result_create(con, sql));
+    Rcpp::traits::input_parameter< bool >::type is_stmnt(is_stmntSEXP);
+    rcpp_result_gen = Rcpp::wrap(result_create(con, sql, is_stmnt));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -268,7 +269,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_RMariaDB_driver_done", (DL_FUNC) &_RMariaDB_driver_done, 0},
     {"_RMariaDB_version", (DL_FUNC) &_RMariaDB_version, 0},
     {"_RMariaDB_init_logging", (DL_FUNC) &_RMariaDB_init_logging, 1},
-    {"_RMariaDB_result_create", (DL_FUNC) &_RMariaDB_result_create, 2},
+    {"_RMariaDB_result_create", (DL_FUNC) &_RMariaDB_result_create, 3},
     {"_RMariaDB_result_column_info", (DL_FUNC) &_RMariaDB_result_column_info, 1},
     {"_RMariaDB_result_fetch", (DL_FUNC) &_RMariaDB_result_fetch, 2},
     {"_RMariaDB_result_bind", (DL_FUNC) &_RMariaDB_result_bind, 2},

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -154,15 +154,15 @@ BEGIN_RCPP
 END_RCPP
 }
 // result_create
-XPtr<MariaResult> result_create(XPtr<MariaConnectionPtr> con, std::string sql, bool is_stmnt);
-RcppExport SEXP _RMariaDB_result_create(SEXP conSEXP, SEXP sqlSEXP, SEXP is_stmntSEXP) {
+XPtr<MariaResult> result_create(XPtr<MariaConnectionPtr> con, std::string sql, bool is_statement);
+RcppExport SEXP _RMariaDB_result_create(SEXP conSEXP, SEXP sqlSEXP, SEXP is_statementSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< XPtr<MariaConnectionPtr> >::type con(conSEXP);
     Rcpp::traits::input_parameter< std::string >::type sql(sqlSEXP);
-    Rcpp::traits::input_parameter< bool >::type is_stmnt(is_stmntSEXP);
-    rcpp_result_gen = Rcpp::wrap(result_create(con, sql, is_stmnt));
+    Rcpp::traits::input_parameter< bool >::type is_statement(is_statementSEXP);
+    rcpp_result_gen = Rcpp::wrap(result_create(con, sql, is_statement));
     return rcpp_result_gen;
 END_RCPP
 }

--- a/src/result.cpp
+++ b/src/result.cpp
@@ -3,9 +3,9 @@
 #include "RMariaDB_types.h"
 
 // [[Rcpp::export]]
-XPtr<MariaResult> result_create(XPtr<MariaConnectionPtr> con, std::string sql) {
+XPtr<MariaResult> result_create(XPtr<MariaConnectionPtr> con, std::string sql, bool is_stmnt = false) {
   (*con)->check_connection();
-  return XPtr<MariaResult>(MariaResult::create_and_send_query(*con, sql), true);
+  return XPtr<MariaResult>(MariaResult::create_and_send_query(*con, sql, is_stmnt), true);
 }
 
 // [[Rcpp::export]]

--- a/src/result.cpp
+++ b/src/result.cpp
@@ -3,9 +3,9 @@
 #include "RMariaDB_types.h"
 
 // [[Rcpp::export]]
-XPtr<MariaResult> result_create(XPtr<MariaConnectionPtr> con, std::string sql, bool is_stmnt = false) {
+XPtr<MariaResult> result_create(XPtr<MariaConnectionPtr> con, std::string sql, bool is_statement = false) {
   (*con)->check_connection();
-  return XPtr<MariaResult>(MariaResult::create_and_send_query(*con, sql, is_stmnt), true);
+  return XPtr<MariaResult>(MariaResult::create_and_send_query(*con, sql, is_statement), true);
 }
 
 // [[Rcpp::export]]

--- a/tests/testthat/test-queries.R
+++ b/tests/testthat/test-queries.R
@@ -10,3 +10,13 @@ test_that("setting parameter query is always complete", {
   dbClearResult(rs)
   dbDisconnect(conn)
 })
+
+# Maybe also relevant for other backends? move to DBItest?
+test_that("prepared statements and SHOW queries", {
+  conn <- mariadbDefault()
+  rs <- dbGetQuery(conn, "SHOW PLUGINS")
+
+  expect_gte(nrow(rs), 1L)
+ 
+  dbDisconnect(conn)
+})


### PR DESCRIPTION
Some queries, such as SHOW bypass the PS framework, causing `mysql_stmt_result_metadata` not to return any metadata at prepare (c.f. [mysqlnd](https://github.com/php/php-src/blob/39327b9/ext/mysqlnd/mysqlnd_ps.c#L442)). A call to `mysql_stmt_result_metadata` at a later time attempts to remedy this issue.

Fixes #67.